### PR TITLE
Install Pebble emulator dependencies + example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PEBBLE_VERSION PebbleSDK-3.1
 
 # update system and get base packages
 RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y curl python2.7-dev python-pip libfreetype6-dev bash-completion && \
+    apt-get install -y curl python2.7-dev python-pip libfreetype6-dev bash-completion libsdl1.2debian libfdt1 libpixman-1-0 libglib2.0-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ container with:
 ```
 docker start -i -a pebbleDev
 ```
+
+To use the emulator, you have to add ```-e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix```. Start the container with:
+```
+docker run -ti --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/pebble-dev/:/pebble/ bboehmke/pebble-dev
+```


### PR DESCRIPTION
I wanted and search for long how to be able to use the pebble emulator when working with docker. I finally found, so i share.
I add the 3 dependencies found in pebble install doc, and also "libglib2.0-dev" was needed.
Then i see how people display interface (like firefox) with the command "-e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix"
